### PR TITLE
Fix target name in `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package(
     name: "LeanplumLocation",
     products: [
-        .library(name: "LeanplumLocation", targets: ["Leanplum-iOS-Location"])
+        .library(name: "LeanplumLocation", targets: ["LeanplumLocation"])
     ],
     targets: [
         .target(


### PR DESCRIPTION
# The problem
When you try to add ` Leanplum-iOS-Location` as a Swift package dependency in a Xcode project you get the following error:

![error2](https://user-images.githubusercontent.com/26303487/146918830-bf7e8538-15ae-4035-8745-eee384223b3c.png)


# The solution

Fix a target name in `Package.swift`.
